### PR TITLE
Add `EncodeInto` to `types.Point` for allocation-free encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ if err != nil {
     panic(err)
 }
 ```
+
+## Benchmarks
+
+`go test ./benchmarks -bench . -benchmem`

--- a/benchmarks/challenge_bench_test.go
+++ b/benchmarks/challenge_bench_test.go
@@ -1,0 +1,59 @@
+package benchmarks
+
+import (
+	"testing"
+
+	"github.com/athanorlabs/go-dleq/ed25519"
+	"github.com/athanorlabs/go-dleq/secp256k1"
+	"github.com/athanorlabs/go-dleq/types"
+	"golang.org/x/crypto/sha3"
+)
+
+var benchMsg = sha3.Sum256([]byte("benchmsg"))
+
+func benchChallenge(b *testing.B, curve types.Curve) {
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+	q := curve.ScalarBaseMul(curve.NewRandomScalar())
+	dstL := make([]byte, curve.CompressedPointSize())
+	dstR := make([]byte, curve.CompressedPointSize())
+
+	eiP, okP := p.(types.PointEncodeInto)
+	eiQ, okQ := q.(types.PointEncodeInto)
+
+	b.Run("with_EncodeInto", func(b *testing.B) {
+		if !(okP && okQ) {
+			b.Skip("curve point does not implement types.PointEncodeInto")
+		}
+		buf := make([]byte, 32+len(dstL)+len(dstR))
+		copy(buf[:32], benchMsg[:])
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			off := 32
+			off += eiP.EncodeInto(buf[off : off+len(dstL)])
+			_ = eiQ.EncodeInto(buf[off : off+len(dstR)])
+			if _, err := curve.HashToScalar(buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("with_Encode", func(b *testing.B) {
+		buf := make([]byte, 32+len(dstL)+len(dstR))
+		copy(buf[:32], benchMsg[:])
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			off := 32
+			L := p.Encode()
+			copy(buf[off:off+len(dstL)], L)
+			off += len(dstL)
+			R := q.Encode()
+			copy(buf[off:off+len(dstR)], R)
+			if _, err := curve.HashToScalar(buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkChallenge_Secp256k1(b *testing.B) { benchChallenge(b, secp256k1.NewCurve()) }
+func BenchmarkChallenge_Ed25519(b *testing.B)   { benchChallenge(b, ed25519.NewCurve()) }

--- a/benchmarks/encodeinto_bench_test.go
+++ b/benchmarks/encodeinto_bench_test.go
@@ -1,0 +1,47 @@
+package benchmarks
+
+import (
+	"testing"
+
+	"github.com/athanorlabs/go-dleq/ed25519"
+	"github.com/athanorlabs/go-dleq/secp256k1"
+	"github.com/athanorlabs/go-dleq/types"
+)
+
+func benchEncodePair(b *testing.B, curve types.Curve) {
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+	dst := make([]byte, curve.CompressedPointSize())
+
+	ei, ok := p.(types.PointEncodeInto)
+	if !ok {
+		b.Skip("curve point does not implement types.PointEncodeInto")
+	}
+
+	b.Run("EncodeInto", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := ei.EncodeInto(dst)
+			if n != len(dst) {
+				b.Fatalf("unexpected length: got %d want %d", n, len(dst))
+			}
+		}
+	})
+
+	b.Run("Encode", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out := p.Encode()
+			if len(out) != len(dst) {
+				b.Fatalf("unexpected length: got %d want %d", len(out), len(dst))
+			}
+		}
+	})
+}
+
+func BenchmarkEncodeInto_vs_Encode_Secp256k1(b *testing.B) {
+	benchEncodePair(b, secp256k1.NewCurve())
+}
+
+func BenchmarkEncodeInto_vs_Encode_Ed25519(b *testing.B) {
+	benchEncodePair(b, ed25519.NewCurve())
+}

--- a/ed25519/curve.go
+++ b/ed25519/curve.go
@@ -370,3 +370,12 @@ func (p *PointImpl) Equals(other Point) bool {
 
 	return p.inner.Equal(pp.inner) == 1
 }
+
+func (p *PointImpl) EncodeInto(dst []byte) int {
+	if len(dst) < 32 {
+		return 0
+	}
+	arr := p.inner.Bytes()
+	copy(dst, arr[:])
+	return 32
+}

--- a/encodeinto_test.go
+++ b/encodeinto_test.go
@@ -1,0 +1,132 @@
+package dleq
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/athanorlabs/go-dleq/ed25519"
+	"github.com/athanorlabs/go-dleq/secp256k1"
+	"github.com/athanorlabs/go-dleq/types"
+)
+
+// --- helpers ---
+
+func allCurves() []types.Curve {
+	return []types.Curve{
+		secp256k1.NewCurve(),
+		ed25519.NewCurve(),
+	}
+}
+
+func mustEqualPoints(t *testing.T, a, b types.Point) {
+	t.Helper()
+	if !a.Equals(b) {
+		t.Fatalf("points are not equal")
+	}
+}
+
+func encodeViaIntoOrFallback(curve types.Curve, p types.Point) []byte {
+	size := curve.CompressedPointSize()
+	dst := make([]byte, size)
+	if ei, ok := p.(types.PointEncodeInto); ok {
+		n := ei.EncodeInto(dst)
+		return dst[:n]
+	}
+	// Fallback: legacy API
+	enc := p.Encode()
+	copy(dst, enc)
+	return dst
+}
+
+// --- tests ---
+
+func TestEncodeInto_SizeAndRoundTrip(t *testing.T) {
+	for _, curve := range allCurves() {
+		// Create a non-trivial point: P = x*G
+		x := curve.NewRandomScalar()
+		P := curve.ScalarBaseMul(x)
+
+		// Encode using EncodeInto (or fallback, if ever missing)
+		out := encodeViaIntoOrFallback(curve, P)
+
+		// Size must match CompressedPointSize()
+		if want, got := curve.CompressedPointSize(), len(out); want != got {
+			t.Fatalf("compressed size mismatch: want %d, got %d", want, got)
+		}
+
+		// Decoding must round-trip to the same point
+		P2, err := curve.DecodeToPoint(out)
+		if err != nil {
+			t.Fatalf("DecodeToPoint failed: %v", err)
+		}
+		mustEqualPoints(t, P, P2)
+	}
+}
+
+func TestEncodeInto_MatchesEncodeBytes(t *testing.T) {
+	for _, curve := range allCurves() {
+		x := curve.NewRandomScalar()
+		P := curve.ScalarBaseMul(x)
+
+		viaInto := encodeViaIntoOrFallback(curve, P)
+		viaEncode := P.Encode()
+
+		if !bytes.Equal(viaInto, viaEncode) {
+			t.Fatalf("EncodeInto bytes differ from Encode() for curve: %#v", curve)
+		}
+	}
+}
+
+// --- micro-benchmarks ---
+
+func BenchmarkPointEncodeInto_Secp256k1(b *testing.B) {
+	curve := secp256k1.NewCurve()
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+
+	ei, ok := p.(types.PointEncodeInto)
+	if !ok {
+		b.Skip("secp256k1 point does not implement EncodeInto")
+	}
+	dst := make([]byte, curve.CompressedPointSize())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ei.EncodeInto(dst)
+	}
+}
+
+func BenchmarkPointEncode_Secp256k1(b *testing.B) {
+	curve := secp256k1.NewCurve()
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = p.Encode()
+	}
+}
+
+func BenchmarkPointEncodeInto_Ed25519(b *testing.B) {
+	curve := ed25519.NewCurve()
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+
+	ei, ok := p.(types.PointEncodeInto)
+	if !ok {
+		b.Skip("ed25519 point does not implement EncodeInto")
+	}
+	dst := make([]byte, curve.CompressedPointSize())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ei.EncodeInto(dst)
+	}
+}
+
+func BenchmarkPointEncode_Ed25519(b *testing.B) {
+	curve := ed25519.NewCurve()
+	p := curve.ScalarBaseMul(curve.NewRandomScalar())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = p.Encode()
+	}
+}

--- a/secp256k1/curve.go
+++ b/secp256k1/curve.go
@@ -414,3 +414,15 @@ func (p *PointImpl) Equals(other Point) bool {
 
 	return ppub.IsEqual(otherPub)
 }
+
+func (p *PointImpl) EncodeInto(dst []byte) int {
+	// secp256k1 compressed is 33 bytes
+	if len(dst) < 33 {
+		return 0
+	}
+	p.inner.ToAffine()
+	pub := secp256k1.NewPublicKey(&p.inner.X, &p.inner.Y)
+
+	b := pub.SerializeCompressed()
+	return copy(dst, b)
+}

--- a/types/types.go
+++ b/types/types.go
@@ -40,3 +40,12 @@ type Point interface {
 	IsZero() bool
 	Equals(other Point) bool
 }
+
+// PointEncodeInto is an optional, zero-alloc encoder for Points.
+// Implementers should write the compressed encoding of the point into dst
+// and return the number of bytes written. dst must have length >=
+/* CompressedPointSize() */ // (callers size with Curve.CompressedPointSize()).
+type PointEncodeInto interface {
+	Point
+	EncodeInto(dst []byte) int
+}


### PR DESCRIPTION
### Description

This PR introduces a new `EncodeInto(dst []byte) int` method on `types.Point`, implemented for both `secp256k1` and `ed25519` points.

The goal is to allow callers (like [ring-go](https://github.com/pokt-network/ring-go)) to reuse buffers when serializing points, instead of always allocating a fresh slice. This is particularly helpful inside signature verification loops where point encoding is on the hot path.

Key changes:

- Added `EncodeInto` to `types.Point` interface.
- Implemented `EncodeInto` for `secp256k1` and `ed25519` points.
- Added benchmarks to compare `Encode` vs `EncodeInto` and demonstrate that:
  - **Neutral on secp256k1** (no regressions).
  - **Fewer allocations on ed25519** (allocation-free path).
- Added simple tests to ensure `EncodeInto` produces the same bytes as `Encode`.

### Benchmarks
Ran on AMD Ryzen 9 5950X, Go 1.23:
```
BenchmarkChallenge_Secp256k1/with_EncodeInto-32       65546   17426 ns/op   1483 B/op   12 allocs/op
BenchmarkChallenge_Secp256k1/with_Encode-32           67558   17454 ns/op   1483 B/op   12 allocs/op

BenchmarkChallenge_Ed25519/with_EncodeInto-32        171180    6961 ns/op   1064 B/op    6 allocs/op
BenchmarkChallenge_Ed25519/with_Encode-32            167292    7025 ns/op   1128 B/op    8 allocs/op

BenchmarkEncodeInto_vs_Encode_Secp256k1/EncodeInto-32 150338   8136 ns/op     48 B/op    1 allocs/op
BenchmarkEncodeInto_vs_Encode_Secp256k1/Encode-32     147151   8121 ns/op     48 B/op    1 allocs/op

BenchmarkEncodeInto_vs_Encode_Ed25519/EncodeInto-32  402760    2935 ns/op      0 B/op    0 allocs/op
BenchmarkEncodeInto_vs_Encode_Ed25519/Encode-32      401104    2988 ns/op     32 B/op    1 allocs/op
```

### Summary

- ✅ Keeps backward compatibility (Encode unchanged).
- ✅ Provides an allocation-free path for projects that want to reuse buffers.
- ✅ Neutral on secp256k1, positive on ed25519.
- ✅ Includes tests and benchmarks to validate behavior.